### PR TITLE
Typo? django-web-packer => django-web-profiler

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Modules used:
 Installation Procedure
 ======================
 
-1. Install django-web-packer using the following command::
+1. Install django-web-profiler using the following command::
 
     pip install django-web-profiler
 


### PR DESCRIPTION
Believe this should reference "django-web-profiler", not "django-web-packer".